### PR TITLE
Fix hanging tests due to Sphinx-contrib-versioning

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -106,7 +106,7 @@ jobs:
       python: "3.6"
       env: REQUIREMENTS=release EXTRAS=all,sqlite SQLALCHEMY_DATABASE_URI="sqlite:///test.db"
       script:
-        - pip install -U git+https://github.com/leokoppel/sphinxcontrib-versioning.git#egg=sphinxcontrib-versioning
+        - pip install -U git+https://github.com/sphinxcontrib-versioning-ng/sphinxcontrib-versioning.git#egg=sphinxcontrib-versioning
         - sphinx-versioning build -T -W "^v[0-9\.]*$" -w master docs/source docs/build/html
       before_deploy:
         - "touch docs/build/html/.nojekyll"

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,8 @@ install_requires = [
 extras_require = {
     'docs': [
         'recommonmark>=0.4.0',
-        'Sphinx>=1.5.1',
+        'Sphinx>=1.5.1,<2.0',  # FIXME: Remove pinning when
+                               # sphinx-contrib-versioning is compatible.
     ],
     'mysql': [
         'invenio-oauthclient[mysql]>=1.0.0',

--- a/shibboleth_authenticator/version.py
+++ b/shibboleth_authenticator/version.py
@@ -23,4 +23,4 @@ and parsed by ``setup.py``.
 """
 
 
-__version__ = '0.1.5'
+__version__ = '0.1.5.post'


### PR DESCRIPTION
`sphinx-contrib-versioning` seems to be not yet compatible with `Sphinx>2.0`. Pin Sphinx as long as build of documentation keeps hanging.

#57 is used to remember unpinning of Sphinx, once the issue is resolved.